### PR TITLE
Added sync_opts to .repo file to override defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ path = centos/5.11/x86_64/updates
 createrepo = true
 ```
 
-Override the default reposync options with repo_opts
+Override the default reposync options with sync_opts
 
 /etc/upstream_sync/mariadb.repo
 ```
@@ -76,13 +76,13 @@ Override the default reposync options with repo_opts
 [mariadb-10.1.12-rhel7]
 url = http://yum.mariadb.org/10.1.12/rhel7-amd64/
 path = mariadb/rhel7/x86_64
-repo_opts = --norepopath --tempcache
+sync_opts = --norepopath --tempcache
 createrepo = true
 
 [mariadb-10.1.11-rhel7]
 url = http://yum.mariadb.org/10.1.11/rhel7-amd64/
 path = mariadb/rhel7/x86_64
-repo_opts = --norepopath --tempcache
+sync_opts = --norepopath --tempcache
 createrepo = true
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,24 @@ path = centos/5.11/x86_64/updates
 createrepo = true
 ```
 
+Override the default reposync options with repo_opts
+
+/etc/upstream_sync/mariadb.repo
+```
+## mariadb 10.1.12 rhel7
+[mariadb-10.1.12-rhel7]
+url = http://yum.mariadb.org/10.1.12/rhel7-amd64/
+path = mariadb/rhel7/x86_64
+repo_opts = --norepopath --tempcache
+createrepo = true
+
+[mariadb-10.1.11-rhel7]
+url = http://yum.mariadb.org/10.1.11/rhel7-amd64/
+path = mariadb/rhel7/x86_64
+repo_opts = --norepopath --tempcache
+createrepo = true
+```
+
 ## Usage
 
 List all Repos that are configured
@@ -81,6 +99,9 @@ Sync all repos
 
 Be verbose while syncing
   `./upstream_sync.py -v`
+
+Show sync and createrepo commands
+  `./upstream_sync.py -c`
 
 ## Mirroring RedHat Repos
 

--- a/upstream_sync.py
+++ b/upstream_sync.py
@@ -31,6 +31,8 @@ def build_yum_config(name, url, sslcacert, sslcert, sslkey):
     repo_conf = os.path.join(tmp_dir, '{0}.repo'.format(name))
 
     f = open(repo_conf, 'w')
+    f.write('[main]\n')
+    f.write('reposdir=/dev/null\n')
     f.write('[{0}]\n'.format(name))
     f.write('name = {0}\n'.format(name))
     f.write('baseurl = {0}\n'.format(url))
@@ -150,11 +152,16 @@ def sync_cmd_reposync(repo):
         logging.warn('unable to detect architecture for %s' % name)
 
     # build options
-    reposync_opts.append('--tempcache')
-    reposync_opts.append('--norepopath')
-    reposync_opts.append('--downloadcomps')
-    reposync_opts.append('--newest-only')
-    reposync_opts.append('--delete')
+    if repo.has_key('sync_opts'):
+        opt_list = repo['sync_opts'].split()
+        for opt in opt_list:
+            reposync_opts.append(opt)
+    else:
+        reposync_opts.append('--tempcache')
+        reposync_opts.append('--norepopath')
+        reposync_opts.append('--downloadcomps')
+        reposync_opts.append('--newest-only')
+        reposync_opts.append('--delete')
 
     # be quiet if verbose is not set
     if not verbose:
@@ -176,11 +183,17 @@ def sync_cmd_rhnget(repo):
 
 def sync_cmd_rsync(repo):
     rsync_opts = []
-    rsync_opts.append('--no-motd')
-    rsync_opts.append('--recursive')
-    rsync_opts.append('--delete')
-    rsync_opts.append('--times')
-    rsync_opts.append('--contimeout=30')
+    # build options
+    if repo.has_key('sync_opts'):
+        opt_list = repo['sync_opts'].split()
+        for opt in opt_list:
+            reposync_opts.append(opt)
+    else:
+        rsync_opts.append('--no-motd')
+        rsync_opts.append('--recursive')
+        rsync_opts.append('--delete')
+        rsync_opts.append('--times')
+        rsync_opts.append('--contimeout=30')
 
     if repo['copylinks'].lower() == 'true':
         rsync_opts.append('--copy-links')

--- a/upstream_sync.py
+++ b/upstream_sync.py
@@ -187,7 +187,7 @@ def sync_cmd_rsync(repo):
     if repo.has_key('sync_opts'):
         opt_list = repo['sync_opts'].split()
         for opt in opt_list:
-            reposync_opts.append(opt)
+            rsync_opts.append(opt)
     else:
         rsync_opts.append('--no-motd')
         rsync_opts.append('--recursive')


### PR DESCRIPTION
Adding a way to override the default options allows for more flexibility to merge multiple repos into one directory (see mariadb example in README).

I also added a [main] section to the repo file creation so it doesn't load repos from /etc/yum.repos.d. This should have been a separate commit and PR but I failed at git commit.
