### PR TITLE
Update upstream_sync.py

### DIFF
--- a/upstream_sync.py
+++ b/upstream_sync.py
@@ -394,7 +394,7 @@ def main():
             if not options.verbose:
                 logging.warn(stdout)
             logging.warn('sync failed: %s' % name)
-            continue  # no need to run createrepo if sync failed
+            sys.exit(p1_rc)  # no need to run createrepo if sync failed
 
         # run createrepo to generate package metadata
         if createrepo:


### PR DESCRIPTION
I propose a change that captures the error code of reposync and passes that through as the exit code for upstream_sync.py 
This would be greatly helpful when running upstream_sync.py in a docker container.